### PR TITLE
Update gdk_pixbuf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 image = { version = "0.23", optional = true }
-gdk-pixbuf = { version = "0.18", optional = true }
+gdk-pixbuf = { version = "0.19", optional = true }
 
 [dev-dependencies]
 image = "0.23"


### PR DESCRIPTION
I updated `gdk_pixbuf` due to a conflicting version with Flare.

Not sure if I should also update the other dependencies, this depends on if WF requires it.