### PR TITLE
Clippy: Replace min/max calls with clamp

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,10 +70,8 @@ pub fn encode(
             actualmaximum_value = f32::max(f32::abs(ac[i as usize][2]), actualmaximum_value);
         }
 
-        let quantised_maximum_value = f32::max(
-            0.,
-            f32::min(82., f32::floor(actualmaximum_value * 166. - 0.5)),
-        ) as u32;
+        let quantised_maximum_value =
+            f32::floor(actualmaximum_value * 166. - 0.5).clamp(0., 82.) as u32;
 
         maximum_value = (quantised_maximum_value + 1) as f32 / 166.;
         blurhash.push_str(&base83::encode(quantised_maximum_value, 1));

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,7 @@ include!(concat!(env!("OUT_DIR"), "/srgb_lookup.rs"));
 
 /// linear 0.0-1.0 floating point to srgb 0-255 integer conversion.
 pub fn linear_to_srgb(value: f32) -> u32 {
-    let v = f32::max(0., f32::min(1., value));
+    let v = value.clamp(0., 1.);
     if v <= 0.003_130_8 {
         (v * 12.92 * 255. + 0.5).round() as u32
     } else {


### PR DESCRIPTION
No significant difference in performance (laptop was a bit warm towards the end anyway)

```
Benchmarking decode LGF5]+Yk^6#M@-5c,1J5@[or[Q6./200: Collecting 100 samples in estimated 5.decode LGF5]+Yk^6#M@-5c,1J5@[or[Q6./200
                        time:   [2.9601 ms 2.9679 ms 2.9769 ms]
                        change: [-0.5812% -0.2357% +0.1341%] (p = 0.20 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe

Benchmarking decode_into LGF5]+Yk^6#M@-5c,1J5@[or[Q6./200: Collecting 100 samples in estimatdecode_into LGF5]+Yk^6#M@-5c,1J5@[or[Q6./200
                        time:   [2.9857 ms 2.9965 ms 3.0077 ms]
                        change: [+0.2166% +0.6813% +1.1576%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

     Running benches/encode.rs (target/release/deps/encode-a9d404ceb3500bd9)
Benchmarking encode data/octocat.png: Collecting 100 samples in estimated 5.2636 s (1800 iteencode data/octocat.png time:   [2.9249 ms 2.9315 ms 2.9389 ms]
                        change: [+2.3760% +2.6619% +2.9393%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 16 outliers among 100 measurements (16.00%)
  16 (16.00%) high severe
```