### PR TITLE
Fix flaky gdk-pixbuf tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,8 +394,9 @@ mod tests {
         )
         .unwrap();
 
-        let bytes = img.save_to_bufferv("png", &[]).unwrap();
-
-        assert_eq!(bytes[1000..1005], [77, 210, 4, 80, 15]);
+        assert_eq!(
+            img.read_pixel_bytes()[1000..1005],
+            [148, 149, 146, 255, 150]
+        );
     }
 }


### PR DESCRIPTION
This now does not encode the data as a png anymore and uses the underlying byte data instead. I hope that is less flaky. This now does not detect <https://github.com/whisperfish/blurhash-rs/pull/11/files#r1313816042> anymore, but its probably better to have a non-flaky test.