### PR TITLE
Use LUT for linear to sRGB conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ image = ">= 0.23, <= 0.25"
 criterion = "0.5"
 
 [features]
-default = []
+default = ["fast-linear-to-srgb"]
 image = [ "dep:image" ]
 gdk-pixbuf = [ "dep:gdk-pixbuf" ]
+fast-linear-to-srgb = []
 
 [[bench]]
 name = "decode"

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 include!(concat!(env!("OUT_DIR"), "/srgb_lookup.rs"));
 
 /// linear 0.0-1.0 floating point to srgb 0-255 integer conversion.
+#[cfg(not(feature = "fast-linear-to-srgb"))]
 pub fn linear_to_srgb(value: f32) -> u8 {
     let v = value.clamp(0., 1.);
     if v <= 0.003_130_8 {
@@ -11,6 +12,15 @@ pub fn linear_to_srgb(value: f32) -> u8 {
         // But we can distribute the latter multiplication, to reduce the number of operations:
         ((1.055 * 255.) * f32::powf(v, 1. / 2.4) - (0.055 * 255. - 0.5)).round() as u8
     }
+}
+
+/// linear 0.0-1.0 floating point to srgb 0-255 integer conversion.
+#[cfg(feature = "fast-linear-to-srgb")]
+pub fn linear_to_srgb(value: f32) -> u8 {
+    let v = value.clamp(0.0, 1.0);
+    let index =
+        ((LINEAR_TO_SRGB_LOOKUP_SIZE as f32 * v) as usize).min(LINEAR_TO_SRGB_LOOKUP_SIZE - 1);
+    LINEAR_TO_SRGB_LOOKUP[index]
 }
 
 /// srgb 0-255 integer to linear 0.0-1.0 floating point conversion.


### PR DESCRIPTION
Using a LUT for the linear to sRGB conversion improves decoding performance for the decode_into benchmark:

```
decode_into LGF5]+Yk^6#M@-5c,1J5@[or[Q6./200
    time:   [766.58 µs 769.86 µs 776.05 µs]
    change: [-62.967% -62.784% -62.602%] (p = 0.00 < 0.05)
    Performance has improved.
```

However, the size of the LUT is 8.192 u8. The `fast-linear-to-srgb` feature flag was added, which is enabled by default. In cases where binary size is more important than performance, the feature can be disabled.

Another note in the implementation: using a lookup table reduces the accuracy of the conversion, compared to the original implementation. But all current tests pass. Higher accuracy can be achieved by increasing the LUT size.