### PR TITLE
Update gdk-pixbuf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 image = { version = ">= 0.23, <= 0.25", optional = true }
-gdk-pixbuf = { version = ">= 0.18, <= 0.19", optional = true }
+gdk-pixbuf = { version = ">= 0.18, <= 0.20", optional = true }
 
 [dev-dependencies]
 image = ">= 0.23, <= 0.25"


### PR DESCRIPTION
Updated some dependencies with Flare and noticed blurhash does not support the newest version of gdk-pixbuf anymore.

We could in theory also remove the upper bound on the version making such MRs not needed for every future version, but may potentially break things.